### PR TITLE
fix(magic-shapes): move arrow text to its own renderer

### DIFF
--- a/client/src/graphs/schematics/edge.ts
+++ b/client/src/graphs/schematics/edge.ts
@@ -149,13 +149,13 @@ export const getEdgeSchematic = (
     }
   }
 
-  const edgeTextAdjustment = fromNodeSize >= 50 ? 0.9 : (fromNodeSize >= 25 ? 1 : 1.3)
+  // const edgeTextAdjustment = fromNodeSize >= 50 ? 0.9 : (fromNodeSize >= 25 ? 1 : 1.3)
 
   const shape = arrow({
     start: edgeStart,
     end: edgeEnd,
     width: edgeWidth,
-    textOffsetFromCenter: fromNodeSize ** edgeTextAdjustment,
+    textOffsetFromCenter: (fromNodeSize + fromNodeBorderWidth / 2) / 2,
     color,
     textArea,
   })

--- a/client/src/shapes/arrow/text.ts
+++ b/client/src/shapes/arrow/text.ts
@@ -4,50 +4,47 @@ import {
   getTextAreaDimension,
   getFullTextArea,
 } from "@shape/text";
-import type { Coordinate } from "@shape/types";
+import { TEXT_DEFAULTS, type Coordinate } from "@shape/types";
 import { rectHitbox } from "@shape/rect/hitbox";
-import { getTextAreaLocationOnLine } from "@shape/line/text";
 import { ARROW_DEFAULTS } from ".";
 import type { Arrow } from ".";
+import { getAngle } from "@shape/helpers";
 
 export const getTextAreaLocationOnArrow = (arrow: Arrow) => {
 
   const {
     textOffsetFromCenter,
-    start: lineStart,
-    end: lineEnd,
+    start,
+    end,
     textArea,
-    width,
-    color
   } = {
     ...ARROW_DEFAULTS,
     ...arrow,
   }
 
-  if (!textArea) throw new Error('no text area provided');
+  if (!textArea) throw new Error('no text area provided')
 
-  const angle = Math.atan2(lineEnd.y - lineStart.y, lineEnd.x - lineStart.x);
-  const arrowHeadHeight = width * 2.5;
+  const { text } = textArea;
 
-  const distanceSquared = (lineStart.x - lineEnd.x) ** 2 + (lineStart.y - lineEnd.y) ** 2;
-
-  const textOffsetIfArrowIsBigAndDistanceIsSmall = distanceSquared ** 0.5 < arrowHeadHeight ? arrowHeadHeight : 0
-
-  const shaftEnd = {
-    x: lineEnd.x - arrowHeadHeight * Math.cos(angle),
-    y: lineEnd.y - arrowHeadHeight * Math.sin(angle),
+  const { fontSize } = {
+    ...TEXT_DEFAULTS,
+    ...text,
   }
 
-  const shaft = {
-    start: lineStart,
-    end: shaftEnd,
-    width,
-    color,
-    textOffsetFromCenter: textOffsetFromCenter - textOffsetIfArrowIsBigAndDistanceIsSmall,
-    textArea,
-  }
+  const angle = getAngle(start, end);
 
-  return getTextAreaLocationOnLine(shaft);
+  const offsetX = textOffsetFromCenter * Math.cos(angle);
+  const offsetY = textOffsetFromCenter * Math.sin(angle);
+
+  const textX = (start.x + end.x) / 2 + offsetX;
+  const textY = (start.y + end.y) / 2 + offsetY;
+
+
+  return {
+    x: textX - fontSize,
+    y: textY - fontSize
+  }
+  
 }
 
 export const arrowTextHitbox = (arrow: Arrow) => {

--- a/client/src/shapes/arrow/text.ts
+++ b/client/src/shapes/arrow/text.ts
@@ -11,7 +11,6 @@ import type { Arrow } from ".";
 import { getAngle } from "@shape/helpers";
 
 export const getTextAreaLocationOnArrow = (arrow: Arrow) => {
-
   const {
     textOffsetFromCenter,
     start,
@@ -39,12 +38,10 @@ export const getTextAreaLocationOnArrow = (arrow: Arrow) => {
   const textX = (start.x + end.x) / 2 + offsetX;
   const textY = (start.y + end.y) / 2 + offsetY;
 
-
   return {
     x: textX - fontSize,
     y: textY - fontSize
   }
-  
 }
 
 export const arrowTextHitbox = (arrow: Arrow) => {

--- a/client/src/shapes/line/text.ts
+++ b/client/src/shapes/line/text.ts
@@ -32,10 +32,10 @@ export const getTextAreaLocationOnLine = (line: Line) => {
     ...text,
   }
 
-  const theta = getAngle(start, end);
+  const angle = getAngle(start, end);
 
-  const offsetX = textOffsetFromCenter * Math.cos(theta);
-  const offsetY = textOffsetFromCenter * Math.sin(theta);
+  const offsetX = textOffsetFromCenter * Math.cos(angle);
+  const offsetY = textOffsetFromCenter * Math.sin(angle);
 
   const textX = (start.x + end.x) / 2 + offsetX;
   const textY = (start.y + end.y) / 2 + offsetY;


### PR DESCRIPTION
Arrow text no longer uses line text as rendering option as this caused some problems (#214, #216). Also removes several imprecise math equations that existed to haphazardly fix these issues.