### PR TITLE
fix(magic-graphs): pressing `F` in name input no longer launches fullscreen

### DIFF
--- a/client/src/ui/core/input/InputText.vue
+++ b/client/src/ui/core/input/InputText.vue
@@ -3,5 +3,7 @@
 </script>
 
 <template>
-  <InputText />
+  <InputText 
+    @keydown.stop
+  />
 </template>


### PR DESCRIPTION
fixes #292 