### PR TITLE
feat(magic-graphs): add autogenerate graph

### DIFF
--- a/client/src/graphs/templates/autoGenerate/AutoGenerate.vue
+++ b/client/src/graphs/templates/autoGenerate/AutoGenerate.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import GButton from "@ui/graph/button/GButton.vue";
+import CIcon from "@ui/core/Icon.vue";
+</script>
+
+<template>
+  <GButton>
+    <CIcon icon="add"></CIcon>
+    Generate New
+  </GButton>
+</template>

--- a/client/src/graphs/templates/autoGenerate/AutoGenerate.vue
+++ b/client/src/graphs/templates/autoGenerate/AutoGenerate.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import GButton from "@ui/graph/button/GButton.vue";
 import CIcon from "@ui/core/Icon.vue";
+import { useAutoGenerate } from "./useAutoGenerate";
+import { nonNullGraph as graph } from "@graph/global";
+
+const { generate } = useAutoGenerate(graph.value);
 </script>
 
 <template>
-  <GButton>
+  <GButton @click="generate">
     <CIcon icon="add"></CIcon>
     Generate New
   </GButton>

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/basicGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/basicGeneration.ts
@@ -1,0 +1,58 @@
+import type { GEdge, GNode } from "@graph/types";
+import type { AutoGenerateGraphOptions } from "@graph/templates/autoGenerate/types";
+import { ref } from "vue";
+import { generateId } from "@utils/id";
+import { graphLabelGetter, LETTERS } from "@graph/labels";
+
+/**
+ * Generates a set of nodes
+ * @param nodeCount The number of nodes to generate.
+ * @returns An array of nodes
+ */
+export const generateNodes = (nodeCount: number) => {
+  const nodes = ref<GNode[]>([]);
+
+  const getLabel = graphLabelGetter(nodes, LETTERS);
+
+  for (let i = 0; i < nodeCount; i++) {
+    nodes.value.push({
+      id: generateId(),
+      label: getLabel(),
+      x: 0,
+      y: 0,
+    });
+  }
+  return nodes.value;
+};
+
+/**
+ * Generates a set of edges between nodes
+ * @param nodes The nodes to generate edges between
+ * @param edgeCount The number of edges to generate
+ * @param edgeLabel The label of the edges
+ * @returns An array of edges
+ */
+export const generateEdges = (
+  nodes: GNode[],
+  edgeCount: number,
+  edgeLabel: AutoGenerateGraphOptions["edgeLabel"]
+) => {
+  const edges: GEdge[] = [];
+  for (let i = 0; i < edgeCount; i++) {
+    const fromNode = nodes[Math.floor(Math.random() * nodes.length)];
+    const toNode = nodes[Math.floor(Math.random() * nodes.length)];
+    const label =
+      typeof edgeLabel === "function"
+        ? edgeLabel(fromNode.id, toNode.id)
+        : edgeLabel!;
+    if (fromNode.id !== toNode.id) {
+      edges.push({
+        id: generateId(),
+        from: fromNode.id,
+        to: toNode.id,
+        label,
+      });
+    }
+  }
+  return edges;
+};

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/forceDirectedLayout.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/forceDirectedLayout.ts
@@ -1,0 +1,95 @@
+import type { GEdge, GNode } from "@graph/types";
+
+type ForceDirectedLayoutOptions = {
+  width: number;
+  height: number;
+  iterations: number;
+};
+
+type PartialForceDirectedLayoutOptions = Partial<ForceDirectedLayoutOptions>;
+
+const FORCE_DIRECTED_LAYOUT_OPTIONS_DEFAULTS = {
+  iterations: 100,
+  width: 1000,
+  height: 1000,
+} as const;
+
+/**
+ * Generates a layout for the given nodes using force-directed layout algorithm.
+ * @param nodes The nodes to generate the layout for.
+ * @param edges The edges to generate the layout for.
+ * @param options The options for the layout algorithm.
+ * @returns The layout for the given nodes.
+ */
+export const forceDirectedLayout = (
+  nodes: GNode[],
+  edges: GEdge[],
+  options: PartialForceDirectedLayoutOptions = {}
+) => {
+  const { width, height, iterations } = {
+    ...FORCE_DIRECTED_LAYOUT_OPTIONS_DEFAULTS,
+    ...options,
+  };
+
+  const area = width * height;
+  const k = Math.sqrt(area / nodes.length);
+  let temperature = width / 10;
+
+  const repulsiveForce = (distance: number) => (k * k) / distance;
+  const attractiveForce = (distance: number) => (distance * distance) / k;
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const displacements = new Map<string, { x: number; y: number }>();
+    nodes.forEach((node) => displacements.set(node.id, { x: 0, y: 0 }));
+
+    nodes.forEach((v) => {
+      nodes.forEach((u) => {
+        if (u.id !== v.id) {
+          const dx = v.x - u.x;
+          const dy = v.y - u.y;
+          const distance = Math.sqrt(dx * dx + dy * dy) || 0.01;
+
+          const force = repulsiveForce(distance);
+
+          const disp = displacements.get(v.id)!;
+          disp.x += (dx / distance) * force;
+          disp.y += (dy / distance) * force;
+        }
+      });
+    });
+
+    edges.forEach((edge) => {
+      const v = nodes.find((n) => n.id === edge.to)!;
+      const u = nodes.find((n) => n.id === edge.from)!;
+
+      const dx = v.x - u.x;
+      const dy = v.y - u.y;
+      const distance = Math.sqrt(dx * dx + dy * dy) || 0.01;
+      const force = attractiveForce(distance);
+
+      const vDisp = displacements.get(v.id)!;
+      const uDisp = displacements.get(u.id)!;
+
+      vDisp.x -= (dx / distance) * force;
+      vDisp.y -= (dy / distance) * force;
+      uDisp.x += (dx / distance) * force;
+      uDisp.y += (dy / distance) * force;
+    });
+
+    nodes.forEach((v) => {
+      const disp = displacements.get(v.id)!;
+      const dispMagnitude =
+        Math.sqrt(disp.x * disp.x + disp.y * disp.y) || 0.01;
+
+      v.x += (disp.x / dispMagnitude) * Math.min(dispMagnitude, temperature);
+      v.y += (disp.y / dispMagnitude) * Math.min(dispMagnitude, temperature);
+
+      v.x = Math.min(width / 2, Math.max(-width / 2, v.x));
+      v.y = Math.min(height / 2, Math.max(-height / 2, v.y));
+    });
+
+    temperature *= 0.9;
+  }
+
+  return nodes;
+};

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/nonRandomLayouts.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/nonRandomLayouts.ts
@@ -1,0 +1,26 @@
+import type { GNode } from "@graph/types";
+
+export const circularLayout = (nodes: GNode[], radius: number) => {
+  const angleStep = (2 * Math.PI) / nodes.length;
+  const circularNodes = nodes.map((node, index) => ({
+    ...node,
+    x: Math.cos(angleStep * index) * radius * 7,
+    y: Math.sin(angleStep * index) * radius * 7,
+  }));
+  return circularNodes;
+};
+
+export const gridLayout = (nodes: GNode[], cellSize: number) => {
+  const gridSize = Math.ceil(Math.sqrt(nodes.length));
+
+  const gridNodes = nodes.map((node, index) => {
+    const row = Math.floor(index / gridSize);
+    const col = index % gridSize;
+    return {
+      ...node,
+      x: col * cellSize + cellSize / 2, // Center in the cell
+      y: row * cellSize + cellSize / 2, // Center in the cell
+    };
+  });
+  return gridNodes;
+};

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/partialMesh.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/partialMesh.ts
@@ -1,0 +1,73 @@
+import type { GEdge, GNode } from "@graph/types";
+import { generateId } from "@utils/id";
+import type { AutoGenerateGraphOptions } from "@graph/templates/autoGenerate/types";
+
+type GeneratePartialMeshOptions = {
+  edgeLabel: AutoGenerateGraphOptions["edgeLabel"];
+  connectionProbability: number;
+  maxConnectionsPerNode: number;
+};
+
+type PartialGeneratePartialMeshOptions = Partial<GeneratePartialMeshOptions>;
+
+const GENERATE_PARTIAL_MESH_DEFAULTS = {
+  edgeLabel: "1",
+  connectionProbability: 0.5,
+  maxConnectionsPerNode: Infinity,
+} as const;
+
+export const generatePartialMesh = (
+  nodes: GNode[],
+  options: PartialGeneratePartialMeshOptions = {}
+) => {
+  const { edgeLabel, connectionProbability, maxConnectionsPerNode } = {
+    ...GENERATE_PARTIAL_MESH_DEFAULTS,
+    ...options,
+  };
+
+  const edges: GEdge[] = [];
+  const connections = new Map<string, number>();
+  const existingEdges = new Set<string>();
+
+  nodes.forEach((node) => connections.set(node.id, 0));
+
+  const addEdge = (from: string, to: string) => {
+    const edgeKey = `${from}-${to}`;
+    if (existingEdges.has(edgeKey)) return;
+
+    const label =
+      typeof edgeLabel === "function" ? edgeLabel(from, to) : edgeLabel!;
+    edges.push({
+      id: generateId(),
+      from,
+      to,
+      label,
+    });
+    connections.set(from, (connections.get(from) || 0) + 1);
+    connections.set(to, (connections.get(to) || 0) + 1);
+    existingEdges.add(edgeKey);
+    existingEdges.add(`${to}-${from}`);
+  };
+
+  for (let i = 0; i < nodes.length - 1; i++) {
+    addEdge(nodes[i].id, nodes[i + 1].id);
+  }
+
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      if (Math.random() < connectionProbability) {
+        const nodeA = nodes[i].id;
+        const nodeB = nodes[j].id;
+
+        if (
+          (connections.get(nodeA) || 0) < maxConnectionsPerNode &&
+          (connections.get(nodeB) || 0) < maxConnectionsPerNode
+        ) {
+          addEdge(nodeA, nodeB);
+        }
+      }
+    }
+  }
+
+  return edges;
+};

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -3,38 +3,8 @@ import type { GEdge, GNode } from "@graph/types";
 import { generateId } from "@utils/id";
 import { ref } from "vue";
 import { angleDifference } from "@shape/helpers";
-
-type GenerateClusterNodesOptions = {
-  clusterCount: number;
-  maxNodesPerCluster: number;
-  minDistance: number;
-  clusterSpread: number;
-};
-
-type PartialGenerateClusterNodesOptions = Partial<GenerateClusterNodesOptions>;
-
-const GENERATE_CLUSTER_GRAPH_DEFAULTS = {
-  clusterCount: 1,
-  maxNodesPerCluster: 15,
-  minDistance: 200,
-  clusterSpread: 350,
-} as const;
-
-type GenerateCohesiveEdgesOptions = {
-  maxEdgesPerNode: number;
-  connectionProbability: number;
-  maxNeighbors: number;
-  minAngleBetweenEdges: number;
-};
-
-type PartialGenerateCohesiveEdgesOptions = Partial<GenerateCohesiveEdgesOptions>
-
-const GENERATE_COHESIVE_EDGES_DEFAULTS = {
-  maxEdgesPerNode: 10,
-  connectionProbability: 0.8,
-  maxNeighbors: 4,
-  minAngleBetweenEdges: Math.PI / 6,
-} as const;
+import type { PartialGenerateClusterNodesOptions, PartialGenerateCohesiveEdgesOptions } from "@graph/templates/autoGenerate/types";
+import { GENERATE_CLUSTER_GRAPH_DEFAULTS, GENERATE_COHESIVE_EDGES_DEFAULTS } from "@graph/templates/autoGenerate/types";
 
 /**
  * Generates an array of nodes distributed across multiple clusters.

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -196,11 +196,12 @@ export const generateCohesiveEdges = (nodes: GNode[], options: PartialGenerateCo
           });
 
         if (angleCheck) {
+          const label = typeof edgeLabel === 'function' ? edgeLabel(fromNode.id, toNode.id) : edgeLabel;
           edges.push({
             id: generateId(),
             from: fromNode.id,
             to: toNode.id,
-            label: "1",
+            label,
           });
           addConnection(fromNode.id, toNode.id);
           edgesAdded++;

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -66,8 +66,16 @@ export const generateClusterNodes = (
   return nodes.value;
 };
 
-
-
+/**
+ * Generates random edges between nodes.
+ *
+ * @param nodes - An array of nodes.
+ * @param maxEdgesPerNode - The maximum number of edges each node can have.
+ * @param connectionProbability - The probability of a node being connected to another node.
+ * @param maxNeighbors - The maximum number of neighbors a node can have.
+ * @param minAngleBetweenEdges - The minimum angle between edges `IN RADIANS`.
+ * @returns An array of edges between nodes.
+ */
 export const generateRandomEdges = (
   nodes: GNode[],
   maxEdgesPerNode: number,
@@ -149,20 +157,20 @@ export const generateRandomEdges = (
         Math.random() <= prob &&
         !usedConnections.get(fromNode.id)?.has(toNode.id)
       ) {
+        const newPotentialEdgeAngle = Math.atan2(
+          toNode.y - fromNode.y,
+          toNode.x - fromNode.x
+        );
         const angleCheck = edges
           .filter((e) => e.from === fromNode.id || e.to === fromNode.id)
           .every((e) => {
-            const existingToNode = nodes.find(
-              (n) => n.id === (e.from === fromNode.id ? e.to : e.from)
-            )!;
-
-            const angle1 = Math.atan2(
-              existingToNode.y - fromNode.y,
-              existingToNode.x - fromNode.x
-            );
-            const angle2 = Math.atan2(toNode.y - fromNode.y, toNode.x - fromNode.x);
-            const angle = angleDifference(angle1, angle2);
-            return angle >= minAngleBetweenEdges;
+            const otherNode = nodes.find((node) => e.from === fromNode.id ? node.id === e.to : node.id === e.from);
+            if (!otherNode) {
+              return false;
+            }
+            const otherNodeAngle = Math.atan2(otherNode.y - fromNode.y, otherNode.x - fromNode.x);
+            const angleDiff = angleDifference(newPotentialEdgeAngle, otherNodeAngle);
+            return angleDiff > minAngleBetweenEdges;
           });
 
         if (angleCheck) {

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -88,7 +88,8 @@ export const generateCohesiveEdges = (nodes: GNode[], options: PartialGenerateCo
     maxEdgesPerNode, 
     connectionProbability, 
     maxNeighbors, 
-    minAngleBetweenEdges 
+    minAngleBetweenEdges,
+    edgeLabel,
   } = {
     ...GENERATE_COHESIVE_EDGES_DEFAULTS,
     ...options,
@@ -134,13 +135,15 @@ export const generateCohesiveEdges = (nodes: GNode[], options: PartialGenerateCo
       }
     }
 
+    const label = typeof edgeLabel === 'function' ? edgeLabel(closestPair!.from, closestPair!.to) : edgeLabel;
+
     if (closestPair) {
       const { from, to } = closestPair;
       edges.push({
         id: generateId(),
         from,
         to,
-        label: "1",
+        label,
       });
       addConnection(from, to);
       connectedNodes.add(to);

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -1,0 +1,184 @@
+import { graphLabelGetter, LETTERS } from "@graph/labels";
+import type { GEdge, GNode } from "@graph/types";
+import { angleDifference } from "@shape/helpers";
+import { generateId } from "@utils/id";
+import { ref } from "vue";
+
+/**
+ * Generates an array of nodes distributed across multiple clusters.
+ *
+ * @param clusterCount - The number of clusters to generate.
+ * @param maxNodesPerCluster - The number of nodes per cluster.
+ * @param maxWidth - The maximum generation width.
+ * @param maxHeight - The maximum generation height.
+ * @param minDistance - The minimum distance between nodes in a cluster.
+ * @param clusterSpread - The maximum radius for nodes in a cluster.
+ * @returns An array of nodes distributed across multiple clusters.
+ */
+export const generateClusterNodes = (
+  clusterCount: number = 1,
+  maxNodesPerCluster: number = 10,
+  maxWidth: number = 1250,
+  maxHeight: number = 1250,
+  minDistance: number = 200,
+  clusterSpread: number = 300
+): GNode[] => {
+  const nodes = ref<GNode[]>([]);
+
+  const minJump = 5; 
+  const maxJump = 20
+
+  const clusterCenters = Array.from({ length: clusterCount }, () => ({
+    x: Math.random() * (maxWidth - clusterSpread * 2) + clusterSpread,
+    y: Math.random() * (maxHeight - clusterSpread * 2) + clusterSpread,
+  }));
+
+  clusterCenters.forEach((center) => {
+    const angleStep = (2 * Math.PI) / maxNodesPerCluster;
+
+    const getLabel = graphLabelGetter(nodes, LETTERS);
+
+    for (let i = 0; i < maxNodesPerCluster; i++) {
+      const angle = angleStep * i * (Math.random() / 10 + 1); 
+      let radius = minDistance; 
+      let x: number, y: number;
+      let retry = 0;
+    
+      do {
+        radius += Math.random() * (maxJump - minJump) + minJump;
+        x = center.x + Math.cos(angle) * radius;
+        y = center.y + Math.sin(angle) * radius;
+        retry++;
+      } while (
+        nodes.value.some(
+          (node) => Math.hypot(node.x - x, node.y - y) < minDistance
+        ) &&
+        retry < 50
+      );
+    
+      nodes.value.push({
+        id: generateId(),
+        label: getLabel(),
+        x: Math.min(Math.max(x, 0), maxWidth),
+        y: Math.min(Math.max(y, 0), maxHeight),
+      });
+    }
+  });
+
+  return nodes.value;
+};
+
+/**
+ * Generates random edges for a list of nodes.
+ * 
+ * @param nodes list of nodes
+ * @param maxEdgesPerNode maximum number of edges per node
+ * @param connectionProbability probability of creating an edge between two nodes
+ * @param maxNeighbors maximum number of neighbors for each node
+ * @param minAngleBetweenEdges minimum allowable angle (in degrees) between edges
+ * @returns list of edges between `nodes`
+ */
+export const generateRandomEdges = (
+  nodes: GNode[],
+  maxEdgesPerNode: number,
+  connectionProbability: number,
+  maxNeighbors: number,
+  minAngleBetweenEdges: number
+): GEdge[] => {
+  const edges: GEdge[] = [];
+
+  const edgeCounts: Record<string, number> = {};
+  nodes.forEach((node) => (edgeCounts[node.id] = 0));
+
+  const calculateAngle = (nodeA: GNode, nodeB: GNode, nodeC: GNode): number => {
+    const vector1 = { x: nodeB.x - nodeA.x, y: nodeB.y - nodeA.y };
+    const vector2 = { x: nodeC.x - nodeA.x, y: nodeC.y - nodeA.y };
+
+    const angle1 = Math.atan2(vector1.y, vector1.x);
+    const angle2 = Math.atan2(vector2.y, vector2.x);
+
+    return angleDifference(angle1, angle2) * (180 / Math.PI);
+  }
+
+  const isEdgeValid = (
+    sourceNode: GNode,
+    targetNode: GNode,
+    existingEdges: GEdge[]
+  ) => {
+    for (const edge of existingEdges) {
+      if (edge.from === sourceNode.id || edge.to === sourceNode.id) {
+        const otherNode = nodes.find(
+          (node) =>
+            node.id === (edge.from === sourceNode.id ? edge.to : edge.from)
+        )!;
+        const angle = calculateAngle(sourceNode, targetNode, otherNode);
+
+        if (angle < minAngleBetweenEdges) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  const getNearestNeighbors = (node: GNode, allNodes: GNode[]) => {
+    return allNodes
+      .filter((otherNode) => otherNode.id !== node.id)
+      .map((otherNode) => ({
+        node: otherNode,
+        distance: Math.hypot(node.x - otherNode.x, node.y - otherNode.y),
+      }))
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, maxNeighbors)
+      .map((entry) => entry.node);
+  }
+
+  nodes.forEach((node) => {
+    const nearestNeighbors = getNearestNeighbors(node, nodes);
+
+    if (nearestNeighbors.length > 0) {
+      const closestNeighbor = nearestNeighbors[0];
+
+      if (
+        edgeCounts[node.id] < maxEdgesPerNode &&
+        edgeCounts[closestNeighbor.id] < maxEdgesPerNode
+      ) {
+        edges.push({
+          id: generateId(),
+          from: node.id,
+          to: closestNeighbor.id,
+          label: "1",
+        });
+        edgeCounts[node.id]++;
+        edgeCounts[closestNeighbor.id]++;
+      }
+    }
+
+    for (let i = 1; i < nearestNeighbors.length; i++) {
+      const neighbor = nearestNeighbors[i];
+
+      if (
+        edgeCounts[node.id] >= maxEdgesPerNode ||
+        edgeCounts[neighbor.id] >= maxEdgesPerNode
+      ) {
+        continue;
+      }
+
+      if (
+        Math.random() <= connectionProbability &&
+        isEdgeValid(node, neighbor, edges)
+      ) {
+        edges.push({
+          id: generateId(),
+          from: node.id,
+          to: neighbor.id,
+          label: "1",
+        });
+        edgeCounts[node.id]++;
+        edgeCounts[neighbor.id]++;
+      }
+    }
+  });
+
+  return edges;
+}

--- a/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
+++ b/client/src/graphs/templates/autoGenerate/generationAlgorithms/randomGeneration.ts
@@ -1,8 +1,8 @@
 import { graphLabelGetter, LETTERS } from "@graph/labels";
 import type { GEdge, GNode } from "@graph/types";
-import { angleDifference } from "@shape/helpers";
 import { generateId } from "@utils/id";
 import { ref } from "vue";
+import { angleDifference } from "@shape/helpers";
 
 /**
  * Generates an array of nodes distributed across multiple clusters.
@@ -18,19 +18,17 @@ import { ref } from "vue";
 export const generateClusterNodes = (
   clusterCount: number = 1,
   maxNodesPerCluster: number = 10,
-  maxWidth: number = 1250,
-  maxHeight: number = 1250,
   minDistance: number = 200,
-  clusterSpread: number = 300
+  clusterSpread: number = 350
 ): GNode[] => {
   const nodes = ref<GNode[]>([]);
 
-  const minJump = 5; 
-  const maxJump = 20
+  const minJump = 5;
+  const maxJump = 20;
 
   const clusterCenters = Array.from({ length: clusterCount }, () => ({
-    x: Math.random() * (maxWidth - clusterSpread * 2) + clusterSpread,
-    y: Math.random() * (maxHeight - clusterSpread * 2) + clusterSpread,
+    x: Math.random() * (clusterSpread * 2) + clusterSpread,
+    y: Math.random() * (clusterSpread * 2) + clusterSpread,
   }));
 
   clusterCenters.forEach((center) => {
@@ -39,28 +37,28 @@ export const generateClusterNodes = (
     const getLabel = graphLabelGetter(nodes, LETTERS);
 
     for (let i = 0; i < maxNodesPerCluster; i++) {
-      const angle = angleStep * i * (Math.random() / 10 + 1); 
-      let radius = minDistance; 
+      const angle = angleStep * i * (Math.random() / 10 + 1);
+      let radius = minDistance;
       let x: number, y: number;
-      let retry = 0;
-    
+      let outwardSteps = 0;
+
       do {
         radius += Math.random() * (maxJump - minJump) + minJump;
         x = center.x + Math.cos(angle) * radius;
         y = center.y + Math.sin(angle) * radius;
-        retry++;
+        outwardSteps++;
       } while (
         nodes.value.some(
           (node) => Math.hypot(node.x - x, node.y - y) < minDistance
         ) &&
-        retry < 50
+        outwardSteps < 100
       );
-    
+
       nodes.value.push({
         id: generateId(),
         label: getLabel(),
-        x: Math.min(Math.max(x, 0), maxWidth),
-        y: Math.min(Math.max(y, 0), maxHeight),
+        x,
+        y,
       });
     }
   });
@@ -68,16 +66,8 @@ export const generateClusterNodes = (
   return nodes.value;
 };
 
-/**
- * Generates random edges for a list of nodes.
- * 
- * @param nodes list of nodes
- * @param maxEdgesPerNode maximum number of edges per node
- * @param connectionProbability probability of creating an edge between two nodes
- * @param maxNeighbors maximum number of neighbors for each node
- * @param minAngleBetweenEdges minimum allowable angle (in degrees) between edges
- * @returns list of edges between `nodes`
- */
+
+
 export const generateRandomEdges = (
   nodes: GNode[],
   maxEdgesPerNode: number,
@@ -86,99 +76,108 @@ export const generateRandomEdges = (
   minAngleBetweenEdges: number
 ): GEdge[] => {
   const edges: GEdge[] = [];
+  const usedConnections = new Map<string, Set<string>>();
 
-  const edgeCounts: Record<string, number> = {};
-  nodes.forEach((node) => (edgeCounts[node.id] = 0));
+  const addConnection = (from: string, to: string) => {
+    if (!usedConnections.has(from)) usedConnections.set(from, new Set());
+    usedConnections.get(from)?.add(to);
+  };
 
-  const calculateAngle = (nodeA: GNode, nodeB: GNode, nodeC: GNode): number => {
-    const vector1 = { x: nodeB.x - nodeA.x, y: nodeB.y - nodeA.y };
-    const vector2 = { x: nodeC.x - nodeA.x, y: nodeC.y - nodeA.y };
+  const distance = (a: GNode, b: GNode): number =>
+    Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
 
-    const angle1 = Math.atan2(vector1.y, vector1.x);
-    const angle2 = Math.atan2(vector2.y, vector2.x);
+  const connectedNodes = new Set<string>();
+  const unconnectedNodes = new Set(nodes.map((node) => node.id));
+  const startNode = nodes[0];
+  connectedNodes.add(startNode.id);
+  unconnectedNodes.delete(startNode.id);
 
-    return angleDifference(angle1, angle2) * (180 / Math.PI);
-  }
+  while (unconnectedNodes.size > 0) {
+    let closestPair: {
+      from: GNode["id"];
+      to: GNode["id"];
+      dist: number;
+    } | null = null;
 
-  const isEdgeValid = (
-    sourceNode: GNode,
-    targetNode: GNode,
-    existingEdges: GEdge[]
-  ) => {
-    for (const edge of existingEdges) {
-      if (edge.from === sourceNode.id || edge.to === sourceNode.id) {
-        const otherNode = nodes.find(
-          (node) =>
-            node.id === (edge.from === sourceNode.id ? edge.to : edge.from)
-        )!;
-        const angle = calculateAngle(sourceNode, targetNode, otherNode);
+    for (const fromId of connectedNodes) {
+      const fromNode = nodes.find((node) => node.id === fromId);
 
-        if (angle < minAngleBetweenEdges) {
-          return false;
+      if (!fromNode) continue;
+
+      for (const toId of unconnectedNodes) {
+        const toNode = nodes.find((node) => node.id === toId);
+        if (!toNode) continue;
+
+        const dist = distance(fromNode, toNode);
+        if (!closestPair || dist < closestPair.dist) {
+          closestPair = { from: fromNode.id, to: toNode.id, dist };
         }
       }
     }
-    return true;
-  }
 
-  const getNearestNeighbors = (node: GNode, allNodes: GNode[]) => {
-    return allNodes
-      .filter((otherNode) => otherNode.id !== node.id)
-      .map((otherNode) => ({
-        node: otherNode,
-        distance: Math.hypot(node.x - otherNode.x, node.y - otherNode.y),
-      }))
-      .sort((a, b) => a.distance - b.distance)
-      .slice(0, maxNeighbors)
-      .map((entry) => entry.node);
-  }
-
-  nodes.forEach((node) => {
-    const nearestNeighbors = getNearestNeighbors(node, nodes);
-
-    if (nearestNeighbors.length > 0) {
-      const closestNeighbor = nearestNeighbors[0];
-
-      if (
-        edgeCounts[node.id] < maxEdgesPerNode &&
-        edgeCounts[closestNeighbor.id] < maxEdgesPerNode
-      ) {
-        edges.push({
-          id: generateId(),
-          from: node.id,
-          to: closestNeighbor.id,
-          label: "1",
-        });
-        edgeCounts[node.id]++;
-        edgeCounts[closestNeighbor.id]++;
-      }
+    if (closestPair) {
+      const { from, to } = closestPair;
+      edges.push({
+        id: generateId(),
+        from,
+        to,
+        label: "1",
+      });
+      addConnection(from, to);
+      connectedNodes.add(to);
+      unconnectedNodes.delete(to);
     }
+  }
 
-    for (let i = 1; i < nearestNeighbors.length; i++) {
-      const neighbor = nearestNeighbors[i];
+  nodes.forEach((fromNode) => {
+    const potentialConnections = nodes
+      .filter((toNode) => fromNode.id !== toNode.id) // remove self
+      .map((toNode) => ({
+        toNode,
+        dist: distance(fromNode, toNode),
+      }))
+      .sort((a, b) => a.dist - b.dist)
+      .slice(0, maxNeighbors);
 
+    let edgesAdded = 0;
+
+    for (const { toNode, dist } of potentialConnections) {
+      if (edgesAdded >= maxEdgesPerNode) break;
+
+      const prob = connectionProbability * Math.exp(-dist / 500);
       if (
-        edgeCounts[node.id] >= maxEdgesPerNode ||
-        edgeCounts[neighbor.id] >= maxEdgesPerNode
+        Math.random() <= prob &&
+        !usedConnections.get(fromNode.id)?.has(toNode.id)
       ) {
-        continue;
-      }
+        const angleCheck = edges
+          .filter((e) => e.from === fromNode.id || e.to === fromNode.id)
+          .every((e) => {
+            const existingToNode = nodes.find(
+              (n) => n.id === (e.from === fromNode.id ? e.to : e.from)
+            )!;
 
-      if (
-        Math.random() <= connectionProbability &&
-        isEdgeValid(node, neighbor, edges)
-      ) {
-        edges.push({
-          id: generateId(),
-          from: node.id,
-          to: neighbor.id,
-          label: "1",
-        });
-        edgeCounts[node.id]++;
-        edgeCounts[neighbor.id]++;
+            const angle1 = Math.atan2(
+              existingToNode.y - fromNode.y,
+              existingToNode.x - fromNode.x
+            );
+            const angle2 = Math.atan2(toNode.y - fromNode.y, toNode.x - fromNode.x);
+            const angle = angleDifference(angle1, angle2);
+            return angle >= minAngleBetweenEdges;
+          });
+
+        if (angleCheck) {
+          edges.push({
+            id: generateId(),
+            from: fromNode.id,
+            to: toNode.id,
+            label: "1",
+          });
+          addConnection(fromNode.id, toNode.id);
+          edgesAdded++;
+        }
       }
     }
   });
 
   return edges;
-}
+};

--- a/client/src/graphs/templates/autoGenerate/types.ts
+++ b/client/src/graphs/templates/autoGenerate/types.ts
@@ -1,22 +1,43 @@
-type GenerateGraphOptions = {
-  edgeType: "directed" | "undirected";
-  edgeLabel: string | ((fromNode: string, toNode: string) => string);
-  edgeLabelMin: string;
-  edgeLabelMax: string;
-  layout: "circular" | "grid" | "partialMesh";
+type GenerateClusterNodesOptions = {
+  clusterCount: number;
+  maxNodesPerCluster: number;
+  minDistance: number;
+  clusterSpread: number;
 };
 
-type PartialGenerateGraphOptions = Partial<GenerateGraphOptions>;
+export type PartialGenerateClusterNodesOptions = Partial<GenerateClusterNodesOptions>;
 
-export type AutoGenerateGraphOptions = {
-  numNodes: number;
-  numEdges: number;
-} & PartialGenerateGraphOptions;
+export const GENERATE_CLUSTER_GRAPH_DEFAULTS = {
+  clusterCount: 1,
+  maxNodesPerCluster: 12,
+  minDistance: 200,
+  clusterSpread: 350,
+} as const;
 
-export const DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS: AutoGenerateGraphOptions = {
-  numNodes: 10,
-  numEdges: 10,
-  edgeType: "directed",
+type GenerateCohesiveEdgesOptions = {
+  maxEdgesPerNode: number;
+  connectionProbability: number;
+  maxNeighbors: number;
+  minAngleBetweenEdges: number;
+};
+
+export type PartialGenerateCohesiveEdgesOptions = Partial<GenerateCohesiveEdgesOptions>;
+
+export const GENERATE_COHESIVE_EDGES_DEFAULTS = {
+  maxEdgesPerNode: 10,
+  connectionProbability: 0.8,
+  maxNeighbors: 4,
+  minAngleBetweenEdges: Math.PI / 6,
+} as const;
+
+export type AutoGenerateGraphOptions = 
+  PartialGenerateClusterNodesOptions &
+  PartialGenerateCohesiveEdgesOptions & {
+    edgeLabel?: string | ((fromNode: string, toNode: string) => string);
+  };
+
+export const AUTO_GENERATE_GRAPH_DEFAULTS = {
+  ...GENERATE_COHESIVE_EDGES_DEFAULTS,
+  ...GENERATE_CLUSTER_GRAPH_DEFAULTS,
   edgeLabel: "1",
-  layout: "partialMesh",
-};
+} as const;

--- a/client/src/graphs/templates/autoGenerate/types.ts
+++ b/client/src/graphs/templates/autoGenerate/types.ts
@@ -3,7 +3,7 @@ type GenerateGraphOptions = {
   edgeLabel: string | ((fromNode: string, toNode: string) => string);
   edgeLabelMin: string;
   edgeLabelMax: string;
-  layout: "circular" | "grid";
+  layout: "circular" | "grid" | "partialMesh";
 };
 
 type PartialGenerateGraphOptions = Partial<GenerateGraphOptions>;
@@ -18,5 +18,5 @@ export const DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS: AutoGenerateGraphOptions = {
   numEdges: 10,
   edgeType: "directed",
   edgeLabel: "1",
-  layout: "circular",
+  layout: "partialMesh",
 };

--- a/client/src/graphs/templates/autoGenerate/types.ts
+++ b/client/src/graphs/templates/autoGenerate/types.ts
@@ -1,0 +1,22 @@
+type GenerateGraphOptions = {
+  edgeType: "directed" | "undirected";
+  edgeLabel: string | ((fromNode: string, toNode: string) => string);
+  edgeLabelMin: string;
+  edgeLabelMax: string;
+  layout: "circular" | "grid";
+};
+
+type PartialGenerateGraphOptions = Partial<GenerateGraphOptions>;
+
+export type AutoGenerateGraphOptions = {
+  numNodes: number;
+  numEdges: number;
+} & PartialGenerateGraphOptions;
+
+export const DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS: AutoGenerateGraphOptions = {
+  numNodes: 10,
+  numEdges: 10,
+  edgeType: "directed",
+  edgeLabel: "1",
+  layout: "circular",
+};

--- a/client/src/graphs/templates/autoGenerate/types.ts
+++ b/client/src/graphs/templates/autoGenerate/types.ts
@@ -19,6 +19,7 @@ type GenerateCohesiveEdgesOptions = {
   connectionProbability: number;
   maxNeighbors: number;
   minAngleBetweenEdges: number;
+  edgeLabel: string | ((fromNode: string, toNode: string) => string);
 };
 
 export type PartialGenerateCohesiveEdgesOptions = Partial<GenerateCohesiveEdgesOptions>;
@@ -28,16 +29,15 @@ export const GENERATE_COHESIVE_EDGES_DEFAULTS = {
   connectionProbability: 0.8,
   maxNeighbors: 4,
   minAngleBetweenEdges: Math.PI / 6,
+  edgeLabel: "1",
 } as const;
 
 export type AutoGenerateGraphOptions = 
   PartialGenerateClusterNodesOptions &
   PartialGenerateCohesiveEdgesOptions & {
-    edgeLabel?: string | ((fromNode: string, toNode: string) => string);
   };
 
 export const AUTO_GENERATE_GRAPH_DEFAULTS = {
   ...GENERATE_COHESIVE_EDGES_DEFAULTS,
   ...GENERATE_CLUSTER_GRAPH_DEFAULTS,
-  edgeLabel: "1",
 } as const;

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -9,7 +9,7 @@ import {
 } from "../helpers";
 import { ref } from "vue";
 import { graphLabelGetter, LETTERS } from "@graph/labels";
-import { generateClusterNodes, generateRandomEdges } from "./generationAlgorithms/randomGeneration";
+import { generateClusterNodes, generateCohesiveEdges } from "./generationAlgorithms/randomGeneration";
 
 
 export const useAutoGenerate = (graph: Graph) => {
@@ -251,8 +251,8 @@ export const useAutoGenerate = (graph: Graph) => {
         // const graphState = generatePartialMesh(nodes.value, edgeLabel, 0.1);
         // nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
         // edges.value = graphState.edges;
-        nodes.value = generateClusterNodes(1, 15)
-        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, Math.PI / 6);
+        nodes.value = generateClusterNodes()
+        edges.value = generateCohesiveEdges(nodes.value);
         break;
       }
     }

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -252,7 +252,7 @@ export const useAutoGenerate = (graph: Graph) => {
         // nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
         // edges.value = graphState.edges;
         nodes.value = generateClusterNodes(1, 15)
-        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, 1);
+        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, Math.PI / 6);
         break;
       }
     }

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -251,8 +251,8 @@ export const useAutoGenerate = (graph: Graph) => {
         // const graphState = generatePartialMesh(nodes.value, edgeLabel, 0.1);
         // nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
         // edges.value = graphState.edges;
-        nodes.value = generateClusterNodes()
-        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, 30);
+        nodes.value = generateClusterNodes(1, 15)
+        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, 1);
         break;
       }
     }

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -1,271 +1,41 @@
 import type { GEdge, GNode, Graph } from "@graph/types";
 import type { AutoGenerateGraphOptions } from "./types";
-import { DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS } from "./types";
-import { generateId } from "@utils/id";
-import { GOLDEN_RATIO } from "@utils/math";
+import { ref } from "vue";
 import {
   centerNodesOnOriginCoordinates,
   getAverageCoordinatesOfNodes,
 } from "../helpers";
-import { ref } from "vue";
-import { graphLabelGetter, LETTERS } from "@graph/labels";
-import { generateClusterNodes, generateCohesiveEdges } from "./generationAlgorithms/randomGeneration";
-
+import {
+  generateClusterNodes,
+  generateCohesiveEdges,
+} from "./generationAlgorithms/randomGeneration";
+import { AUTO_GENERATE_GRAPH_DEFAULTS } from "./types";
 
 export const useAutoGenerate = (graph: Graph) => {
-  const generateNodes = (nodeCount: number) => {
-    const nodes = ref<GNode[]>([]);
+  const options = ref<AutoGenerateGraphOptions>({
+    ...AUTO_GENERATE_GRAPH_DEFAULTS,
+  });
 
-    const getLabel = graphLabelGetter(nodes, LETTERS);
+  const nodes = ref<GNode[]>([]);
+  const edges = ref<GEdge[]>([]);
 
-    for (let i = 0; i < nodeCount; i++) {
-      nodes.value.push({
-        id: generateId(),
-        label: getLabel(),
-        x: 0,
-        y: 0,
-      });
-    }
-    return nodes.value;
-  };
-
-  const generateEdges = (
-    nodes: GNode[],
-    edgeCount: number,
-    edgeLabel: AutoGenerateGraphOptions["edgeLabel"]
-  ) => {
-    const edges: GEdge[] = [];
-    for (let i = 0; i < edgeCount; i++) {
-      const fromNode = nodes[Math.floor(Math.random() * nodes.length)];
-      const toNode = nodes[Math.floor(Math.random() * nodes.length)];
-      const label =
-        typeof edgeLabel === "function"
-          ? edgeLabel(fromNode.id, toNode.id)
-          : edgeLabel!;
-      if (fromNode.id !== toNode.id) {
-        edges.push({
-          id: generateId(),
-          from: fromNode.id,
-          to: toNode.id,
-          label,
-        });
-      }
-    }
-    return edges;
-  };
-
-  const circularLayout = (nodes: GNode[]) => {
-    const angleStep = (2 * Math.PI) / nodes.length;
-    const radius = graph.baseTheme.value.nodeSize * GOLDEN_RATIO;
-    const circularNodes = nodes.map((node, index) => ({
-      ...node,
-      x: Math.cos(angleStep * index) * radius * 7,
-      y: Math.sin(angleStep * index) * radius * 7,
-    }));
-    return circularNodes;
-  };
-
-  const gridLayout = (nodes: GNode[]) => {
-    const gridSize = Math.ceil(Math.sqrt(nodes.length));
-    const cellSize = graph.baseTheme.value.nodeSize * GOLDEN_RATIO * 5;
-
-    const gridNodes = nodes.map((node, index) => {
-      const row = Math.floor(index / gridSize);
-      const col = index % gridSize;
-      return {
-        ...node,
-        x: col * cellSize + cellSize / 2, // Center in the cell
-        y: row * cellSize + cellSize / 2, // Center in the cell
-      };
-    });
-    return gridNodes;
-  };
-
-  const generatePartialMesh = (
-    nodes: GNode[],
-    edgeLabel: AutoGenerateGraphOptions["edgeLabel"],
-    connectionProbability: number,
-    maxConnectionsPerNode: number = Infinity
-  ): { nodes: GNode[]; edges: GEdge[] } => {
-    const edges: GEdge[] = [];
-    const connections = new Map<string, number>();
-    const existingEdges = new Set<string>();
-
-    connectionProbability = Math.max(0, Math.min(1, connectionProbability));
-
-    nodes.forEach((node) => connections.set(node.id, 0));
-
-    const addEdge = (from: string, to: string) => {
-      const edgeKey = `${from}-${to}`;
-      if (existingEdges.has(edgeKey)) return;
-
-      const label =
-        typeof edgeLabel === "function" ? edgeLabel(from, to) : edgeLabel!;
-      edges.push({
-        id: generateId(),
-        from,
-        to,
-        label,
-      });
-      connections.set(from, (connections.get(from) || 0) + 1);
-      connections.set(to, (connections.get(to) || 0) + 1);
-      existingEdges.add(edgeKey);
-      existingEdges.add(`${to}-${from}`); 
-    };
-
-    for (let i = 0; i < nodes.length - 1; i++) {
-      addEdge(nodes[i].id, nodes[i + 1].id);
-    }
-
-    for (let i = 0; i < nodes.length; i++) {
-      for (let j = i + 1; j < nodes.length; j++) {
-        if (Math.random() < connectionProbability) {
-          const nodeA = nodes[i].id;
-          const nodeB = nodes[j].id;
-
-          if (
-            (connections.get(nodeA) || 0) < maxConnectionsPerNode &&
-            (connections.get(nodeB) || 0) < maxConnectionsPerNode
-          ) {
-            addEdge(nodeA, nodeB);
-          }
-        }
-      }
-    }
-
-    return { nodes, edges };
-  };
-
-  const forceDirectedLayout = (
-    nodes: GNode[],
-    edges: GEdge[],
-    iterations: number = 100,
-    width: number = 1000,
-    height: number = 1000,
-    buffer: number = 50, // minimum buffer zone between nodes
-    perturbation: number = 50 // small random displacement to prevent colinearity
-  ): GNode[] => {
-    const area = width * height;
-    const k = Math.sqrt(area / nodes.length); 
-    let temperature = width / 10; 
-  
-    const repulsiveForce = (distance: number) => (k * k) / distance;
-    const attractiveForce = (distance: number) => (distance * distance) / k;
-  
-    const isColinear = (a: GNode, b: GNode, c: GNode): boolean => {
-      const crossProduct = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
-      return Math.abs(crossProduct) < 1e-5; 
-    };
-  
-    const applyPerturbation = (node: GNode) => {
-      node.x += Math.random() * perturbation - perturbation / 2;
-      node.y += Math.random() * perturbation - perturbation / 2;
-    };
-  
-    for (let iter = 0; iter < iterations; iter++) {
-      const displacements = new Map<string, { x: number; y: number }>();
-      nodes.forEach((node) => displacements.set(node.id, { x: 0, y: 0 }));
-  
-      nodes.forEach((v) => {
-        nodes.forEach((u) => {
-          if (u.id !== v.id) {
-            const dx = v.x - u.x;
-            const dy = v.y - u.y;
-            const distance = Math.sqrt(dx * dx + dy * dy) || 0.01; 
-  
-            let force = repulsiveForce(distance);
-            if (distance < buffer) {
-              force += (buffer - distance) * 2;
-            }
-  
-            const disp = displacements.get(v.id)!;
-            disp.x += (dx / distance) * force;
-            disp.y += (dy / distance) * force;
-          }
-        });
-      });
-  
-      edges.forEach((edge) => {
-        const v = nodes.find((n) => n.id === edge.to)!;
-        const u = nodes.find((n) => n.id === edge.from)!;
-  
-        const dx = v.x - u.x;
-        const dy = v.y - u.y;
-        const distance = Math.sqrt(dx * dx + dy * dy) || 0.01; 
-        const force = attractiveForce(distance);
-  
-        const vDisp = displacements.get(v.id)!;
-        const uDisp = displacements.get(u.id)!;
-  
-        vDisp.x -= (dx / distance) * force;
-        vDisp.y -= (dy / distance) * force;
-        uDisp.x += (dx / distance) * force;
-        uDisp.y += (dy / distance) * force;
-      });
-  
-      nodes.forEach((v) => {
-        const disp = displacements.get(v.id)!;
-        const dispMagnitude = Math.sqrt(disp.x * disp.x + disp.y * disp.y) || 0.01;
-  
-        v.x += (disp.x / dispMagnitude) * Math.min(dispMagnitude, temperature);
-        v.y += (disp.y / dispMagnitude) * Math.min(dispMagnitude, temperature);
-  
-        v.x = Math.min(width / 2, Math.max(-width / 2, v.x));
-        v.y = Math.min(height / 2, Math.max(-height / 2, v.y));
-      });
-  
-      for (let i = 0; i < nodes.length; i++) {
-        for (let j = i + 1; j < nodes.length; j++) {
-          for (let k = j + 1; k < nodes.length; k++) {
-            if (isColinear(nodes[i], nodes[j], nodes[k])) {
-              applyPerturbation(nodes[k]); 
-            }
-          }
-        }
-      }
-  
-      temperature *= 0.9;
-    }
-  
-    return nodes;
-  };
-
-  const generate = (options: AutoGenerateGraphOptions) => {
-    const { layout } = {
-      ...DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS,
-      ...options,
-    };
-
-    const nodes = ref();
-    const edges = ref();
-
-    switch (layout) {
-      case "circular":
-        nodes.value = circularLayout(nodes.value);
-        break;
-      case "grid":
-        nodes.value = gridLayout(nodes.value);
-        break;
-      case "partialMesh": {
-        
-        // const graphState = generatePartialMesh(nodes.value, edgeLabel, 0.1);
-        // nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
-        // edges.value = graphState.edges;
-        nodes.value = generateClusterNodes()
-        edges.value = generateCohesiveEdges(nodes.value);
-        break;
-      }
-    }
+  const generate = () => {
+    const generatedNodes = generateClusterNodes(options.value);
     const origin = getAverageCoordinatesOfNodes(graph.nodes.value);
-    const centeredNodes = centerNodesOnOriginCoordinates(nodes.value, origin);
-
-    graph.load({
-      nodes: centeredNodes,
-      edges: edges.value,
-    });
+    const centeredNodes = centerNodesOnOriginCoordinates(
+      generatedNodes,
+      origin
+    );
+    edges.value = generateCohesiveEdges(centeredNodes, options.value);
+    nodes.value = centeredNodes;
+    graph.load({ nodes: nodes.value, edges: edges.value });
   };
 
   return {
     generate,
+
+    options,
+    nodes,
+    edges,
   };
 };

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -9,6 +9,7 @@ import {
 } from "../helpers";
 import { ref } from "vue";
 import { graphLabelGetter, LETTERS } from "@graph/labels";
+import { generateClusterNodes, generateRandomEdges } from "./generationAlgorithms/randomGeneration";
 
 
 export const useAutoGenerate = (graph: Graph) => {
@@ -230,13 +231,13 @@ export const useAutoGenerate = (graph: Graph) => {
   };
 
   const generate = (options: AutoGenerateGraphOptions) => {
-    const { numNodes, numEdges, edgeLabel, layout } = {
+    const { layout } = {
       ...DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS,
       ...options,
     };
 
-    const nodes = ref(generateNodes(numNodes));
-    const edges = ref(generateEdges(nodes.value, numEdges, edgeLabel));
+    const nodes = ref();
+    const edges = ref();
 
     switch (layout) {
       case "circular":
@@ -246,9 +247,12 @@ export const useAutoGenerate = (graph: Graph) => {
         nodes.value = gridLayout(nodes.value);
         break;
       case "partialMesh": {
-        const graphState = generatePartialMesh(nodes.value, edgeLabel, 0.1);
-        nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
-        edges.value = graphState.edges;
+        
+        // const graphState = generatePartialMesh(nodes.value, edgeLabel, 0.1);
+        // nodes.value = forceDirectedLayout(graphState.nodes, graphState.edges);
+        // edges.value = graphState.edges;
+        nodes.value = generateClusterNodes()
+        edges.value = generateRandomEdges(nodes.value, 10, 0.8, 4, 30);
         break;
       }
     }

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -1,0 +1,107 @@
+import type { GEdge, GNode, Graph } from "@graph/types";
+import type { AutoGenerateGraphOptions } from "./types";
+import { DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS } from "./types";
+import { generateId } from "@utils/id";
+import { GOLDEN_RATIO } from "@utils/math";
+import {
+  centerNodesOnOriginCoordinates,
+  getAverageCoordinatesOfNodes,
+} from "../helpers";
+import { ref } from "vue";
+
+export const useAutoGenerate = (graph: Graph) => {
+  const generateNodes = (nodeCount: number) => {
+    return Array.from({ length: nodeCount }, () => ({
+      id: generateId(),
+      label: "fhsdj",
+      x: 10,
+      y: 10,
+    }));
+  };
+
+  const generateEdges = (
+    nodes: GNode[],
+    edgeCount: number,
+    edgeLabel: AutoGenerateGraphOptions["edgeLabel"]
+  ) => {
+    const edges: GEdge[] = [];
+    for (let i = 0; i < edgeCount; i++) {
+      const fromNode = nodes[Math.floor(Math.random() * nodes.length)];
+      const toNode = nodes[Math.floor(Math.random() * nodes.length)];
+      const label =
+        typeof edgeLabel === "function"
+          ? edgeLabel(fromNode.id, toNode.id)
+          : edgeLabel!;
+      if (fromNode.id !== toNode.id) {
+        edges.push({
+          id: generateId(),
+          from: fromNode.id,
+          to: toNode.id,
+          label,
+        });
+      }
+    }
+    return edges;
+  };
+
+  const circularLayout = (nodes: GNode[]) => {
+    const origin = getAverageCoordinatesOfNodes(graph.nodes.value);
+    console.log(origin);
+    const angleStep = (2 * Math.PI) / nodes.length;
+    const radius = graph.baseTheme.value.nodeSize * GOLDEN_RATIO;
+    const circularNodes = nodes.map((node, index) => ({
+      ...node,
+      x: Math.cos(angleStep * index) * radius * 8,
+      y: Math.sin(angleStep * index) * radius * 8,
+    }));
+    const centeredNodes = centerNodesOnOriginCoordinates(circularNodes, origin);
+    return centeredNodes;
+  };
+
+  const gridLayout = (nodes: GNode[]) => {
+    const origin = getAverageCoordinatesOfNodes(graph.nodes.value);
+
+    const gridSize = Math.ceil(Math.sqrt(nodes.length));
+    const cellSize = graph.baseTheme.value.nodeSize * GOLDEN_RATIO * 5;
+
+    const gridNodes = nodes.map((node, index) => {
+      const row = Math.floor(index / gridSize);
+      const col = index % gridSize;
+      return {
+        ...node,
+        x: col * cellSize + cellSize / 2, // Center in the cell
+        y: row * cellSize + cellSize / 2, // Center in the cell
+      };
+    });
+    const centeredNodes = centerNodesOnOriginCoordinates(gridNodes, origin);
+    return centeredNodes;
+  };
+
+  const generate = (options: AutoGenerateGraphOptions) => {
+    const { numNodes, numEdges, edgeLabel, layout } = {
+      ...DEFAULT_AUTO_GENERATE_GRAPH_OPTIONS,
+      ...options,
+    };
+
+    const nodes = ref(generateNodes(numNodes) as GNode[]);
+    const edges = ref(generateEdges(nodes.value, numEdges, edgeLabel));
+
+    switch (layout) {
+      case "circular":
+        nodes.value = circularLayout(nodes.value);
+        break;
+      case "grid":
+        nodes.value = gridLayout(nodes.value);
+        break;
+    }
+
+    graph.load({
+      nodes: nodes.value,
+      edges: edges.value,
+    });
+  };
+
+  return {
+    generate,
+  };
+};

--- a/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
+++ b/client/src/graphs/templates/autoGenerate/useAutoGenerate.ts
@@ -21,8 +21,8 @@ export const useAutoGenerate = (graph: Graph) => {
       nodes.value.push({
         id: generateId(),
         label: getLabel(),
-        x: Math.random() * 1000,
-        y: Math.random() * 1000,
+        x: 0,
+        y: 0,
       });
     }
     return nodes.value;

--- a/client/src/graphs/templates/ui/TemplateMenu.vue
+++ b/client/src/graphs/templates/ui/TemplateMenu.vue
@@ -6,7 +6,8 @@
   import { useGraphTemplate } from "../useGraphTemplate";
   import GButton from "@ui/graph/button/GButton.vue";
   import TemplateItem from "./TemplateItem.vue";
-
+  import AutoGenerate from "../autoGenerate/AutoGenerate.vue";
+  
   const {
     templates,
     userTemplates,
@@ -52,8 +53,6 @@
         </div>
       </div>
 
-      <hr class="my-2" />
-
       <div class="flex gap-2 justify-center">
         <GButton 
           @click="add" 
@@ -63,7 +62,10 @@
           @click="clearUserTemplates" 
           :disabled="userTemplates.length === 0"
         >Clear All</GButton>
+
       </div>
+      <hr class="my-2" />
+      <AutoGenerate />
     </GWell>
   </CPopover>
 </template>

--- a/client/src/shapes/helpers.ts
+++ b/client/src/shapes/helpers.ts
@@ -171,4 +171,5 @@ export const calculateArrowHeadCorners = (options: Required<Pick<Arrow, 'start' 
  * @param angleB The second angle in radians.
  * @returns The difference between the two angles in radians.
  */
-export const angleDifference = (angleA: number, angleB: number) => Math.atan2(Math.sin(angleA - angleB), Math.cos(angleA - angleB));
+export const angleDifference = (angleA: number, angleB: number) => 
+  Math.abs(Math.atan2(Math.sin(angleA - angleB), Math.cos(angleA - angleB)));

--- a/client/src/shapes/helpers.ts
+++ b/client/src/shapes/helpers.ts
@@ -165,4 +165,10 @@ export const calculateArrowHeadCorners = (options: Required<Pick<Arrow, 'start' 
   };
 };
 
-const angleDifference = (angleA: number, angleB: number) => Math.atan2(Math.sin(angleA - angleB), Math.cos(angleA - angleB));
+/**
+ * Calculates the difference between two angles in radians.
+ * @param angleA The first angle in radians.
+ * @param angleB The second angle in radians.
+ * @returns The difference between the two angles in radians.
+ */
+export const angleDifference = (angleA: number, angleB: number) => Math.atan2(Math.sin(angleA - angleB), Math.cos(angleA - angleB));

--- a/client/src/shapes/helpers.ts
+++ b/client/src/shapes/helpers.ts
@@ -164,3 +164,5 @@ export const calculateArrowHeadCorners = (options: Required<Pick<Arrow, 'start' 
     pointC: baseRight,
   };
 };
+
+const angleDifference = (angleA: number, angleB: number) => Math.atan2(Math.sin(angleA - angleB), Math.cos(angleA - angleB));


### PR DESCRIPTION
fixes #280 

added: 
🎲working, and pretty decent graph generation for smaller graphs (8-20) nodes that should fit most use cases and draws fairly clean and predictable patterns
🎲 several other algorithms which generate worse looking graphs but have many more unique shapes to them (might improve these later). Includes Force-Layout spacing algo and partial mesh edge generation algo.
🎲added new button to template menu to generate graph
🎲added shape layouts for nodes such as circle and grid

@MwKau thanks for algo help :)