### PR TITLE
feat(product): add UI polish

### DIFF
--- a/client/src/graphs/plugins/annotations/index.ts
+++ b/client/src/graphs/plugins/annotations/index.ts
@@ -64,6 +64,22 @@ export const useAnnotations = (graph: BaseGraph) => {
   const startDrawing = ({ coords, event }: GraphMouseEvent) => {
     if (event.button !== MOUSE_BUTTONS.left) return;
 
+    if (isErasing.value) {
+      const eraserBoundingBox = getCircleBoundingBox({
+        at: coords,
+        radius: ERASER_BRUSH_RADIUS,
+      })();
+
+      const erasedScribbles = scribbles.value.filter((scribble) => {
+        const shape = shapes.scribble(scribble);
+        return shape.efficientHitbox(eraserBoundingBox);
+      });
+
+      for (const erasedScribble of erasedScribbles) {
+        erasedScribbleIds.value.add(erasedScribble.id);
+      }
+    }
+
     isDrawing.value = true;
     lastPoint.value = coords;
     batch.value = [coords];

--- a/client/src/graphs/plugins/interactive/index.ts
+++ b/client/src/graphs/plugins/interactive/index.ts
@@ -8,6 +8,9 @@ import type { NodeAnchor } from '@graph/plugins/anchors/types';
  */
 export const useInteractive = (graph: BaseGraph) => {
   const handleNodeCreation = ({ coords, event }: GraphMouseEvent) => {
+    const itemStack = graph.getSchemaItemsByCoordinates(coords);
+    if (itemStack.at(-1)?.graphType === 'node') return;
+
     const nodeAdded = graph.addNode(coords);
     if (!nodeAdded) return;
     setTimeout(() => graph.updateGraphAtMousePosition(event), 10);

--- a/client/src/ui/product/GraphProduct.vue
+++ b/client/src/ui/product/GraphProduct.vue
@@ -47,6 +47,7 @@
   };
 
   const setActiveSimulation = (simulation: SimulationDeclaration) => {
+    props.graph.annotation.deactivate();
     activeSimulation.value = simulation;
     startSimulation();
   };
@@ -172,7 +173,6 @@
         <SelectSimulation
           @simulation-selected="setActiveSimulation"
           :simulations="simulations"
-          :disabled="graph.annotation.isActive.value"
         />
       </slot>
     </template>

--- a/client/src/ui/product/GraphProduct.vue
+++ b/client/src/ui/product/GraphProduct.vue
@@ -20,6 +20,8 @@
     graph: Graph;
   }>();
 
+  const wasAnnotationActive = ref(false);
+
   const emit = defineEmits<{
     (e: 'graph-ref', value: HTMLCanvasElement | undefined): void;
     (e: 'simulation-started', value: UnwrapRef<SimulationDeclaration>): void;
@@ -44,10 +46,15 @@
     await simRunner.value.stop();
     runningSimulation.value = false;
     emit('simulation-stopped');
+
+    if (wasAnnotationActive.value) props.graph.annotation.activate();
+    wasAnnotationActive.value = false;
   };
 
   const setActiveSimulation = (simulation: SimulationDeclaration) => {
+    wasAnnotationActive.value = props.graph.annotation.isActive.value;
     props.graph.annotation.deactivate();
+
     activeSimulation.value = simulation;
     startSimulation();
   };


### PR DESCRIPTION
added:
- starting simulation turns off annotations (with persistence)
- can no longer spawn node on top of another node
- annotation eraser works on click


addresses issues #401, #405, #402