### PR TITLE
fix: undo bug

### DIFF
--- a/client/src/graphs/plugins/annotations/index.ts
+++ b/client/src/graphs/plugins/annotations/index.ts
@@ -13,6 +13,7 @@ import type { Annotation } from './types';
 import { useNonNullGraphColors } from '@graph/themes/useGraphColors';
 import { getCircleBoundingBox } from '@shape/circle/hitbox';
 import { MOUSE_BUTTONS } from '@graph/global';
+import type { IntervalHandler } from '@utils/types';
 
 const ERASER_BRUSH_RADIUS = 10;
 
@@ -23,7 +24,7 @@ export const useAnnotations = (graph: BaseGraph) => {
   const selectedBrushWeight = ref(BRUSH_WEIGHTS[1]);
   const isErasing = ref(false);
   const isLaserPointing = ref(false);
-  const laserDecayInterval = ref<NodeJS.Timeout>();
+  const laserDecayInterval = ref<IntervalHandler>();
   const lastMoveTime = ref(Date.now());
   const erasedScribbleIds = ref(new Set<string>());
 

--- a/client/src/graphs/plugins/history/index.ts
+++ b/client/src/graphs/plugins/history/index.ts
@@ -133,7 +133,7 @@ export const useHistory = (graph: BaseGraph) => {
       if (!history) return;
 
       pendingNodeRemovals.value.push(...removedNodes);
-      pendingEdgeRemovals.value.push(...removedEdges); // These edges are already part of node deletion
+      pendingEdgeRemovals.value.push(...removedEdges);
 
       if (!removalTimeout.value) {
         removalTimeout.value = setTimeout(processRemovals, 0);

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -9,7 +9,7 @@ export type PartiallyPartial<T, K extends keyof T> = Omit<T, K> &
  * takes `any[]` out of a union of arrays
  * @example RemoveAnyArray<number[] | any[]> // number[]
  */
-export type RemoveAnyArray<T extends any[]> = Exclude<
+export type RemoveAnyArray<T extends unknown[]> = Exclude<
   T,
   ['!!!-@-NOT-A-TYPE-@-!!!'][]
 >;
@@ -38,3 +38,6 @@ export type KeyboardEventEntries = [
   keyof KeyboardEventMap,
   (ev: KeyboardEvent) => void,
 ][];
+
+export type TimeoutHandler = ReturnType<typeof setTimeout>;
+export type IntervalHandler = ReturnType<typeof setInterval>;


### PR DESCRIPTION
see issue #406 

- Queues nodes and edges into temporary lists (pendingNodeRemovals and pendingEdgeRemovals).
- Uses a short delay (setTimeout(..., 0)) to group both events together if they occur within the same event loop.
- Single undo entry is created for both nodes and edges.