### PR TITLE
fix: history did not handle loading

### DIFF
--- a/client/src/graphs/base/index.ts
+++ b/client/src/graphs/base/index.ts
@@ -24,7 +24,11 @@ import { useNodeEdgeMap } from './useNodeEdgeMap';
 import { useAggregator } from './useAggregator';
 import { useGraphCRUD } from './useGraphCRUD';
 import { getCtx } from '@utils/ctx';
-import type { GraphAtMousePosition } from './types';
+import {
+  LOAD_GRAPH_OPTIONS_DEFAULTS,
+  type GraphAtMousePosition,
+  type HistoryOption,
+} from './types';
 import { useGraphCursor } from './useGraphCursor';
 import { getCanvasCoords } from '@utils/components/useCanvasCoord';
 import { useAnimationController } from '@graph/animationController';
@@ -269,10 +273,25 @@ export const useBaseGraph = (
    * load a graph state into the graph
    * @param graphState - the graph state to load (nodes and edges)
    */
-  const load = (graphState: { nodes: GNode[]; edges: GEdge[] }) => {
+  const load = (
+    graphState: { nodes: GNode[]; edges: GEdge[] },
+    options?: HistoryOption,
+  ) => {
+    // save current state
+    const previousState = {
+      nodes: nodes.value,
+      edges: edges.value,
+    };
+
     nodes.value = graphState.nodes;
     edges.value = graphState.edges;
-    emit('onGraphLoaded');
+
+    const historyOptions = {
+      ...LOAD_GRAPH_OPTIONS_DEFAULTS,
+      ...options,
+    };
+
+    emit('onGraphLoaded', previousState, historyOptions);
     emit('onStructureChange');
   };
 

--- a/client/src/graphs/base/index.ts
+++ b/client/src/graphs/base/index.ts
@@ -24,16 +24,12 @@ import { useNodeEdgeMap } from './useNodeEdgeMap';
 import { useAggregator } from './useAggregator';
 import { useGraphCRUD } from './useGraphCRUD';
 import { getCtx } from '@utils/ctx';
-import {
-  LOAD_GRAPH_OPTIONS_DEFAULTS,
-  type GraphAtMousePosition,
-  type HistoryOption,
-} from './types';
+import { LOAD_GRAPH_OPTIONS_DEFAULTS } from './types';
+import type { GraphAtMousePosition, HistoryOption } from './types';
 import { useGraphCursor } from './useGraphCursor';
 import { getCanvasCoords } from '@utils/components/useCanvasCoord';
 import { useAnimationController } from '@graph/animationController';
 import { usePluginHoldController } from './usePluginHold';
-
 export const useBaseGraph = (
   canvas: Ref<HTMLCanvasElement | undefined | null>,
   startupSettings: Partial<GraphSettings> = {},
@@ -277,7 +273,6 @@ export const useBaseGraph = (
     graphState: { nodes: GNode[]; edges: GEdge[] },
     options?: HistoryOption,
   ) => {
-    // save current state
     const previousState = {
       nodes: nodes.value,
       edges: edges.value,

--- a/client/src/graphs/base/types.ts
+++ b/client/src/graphs/base/types.ts
@@ -88,6 +88,10 @@ export const BULK_ADD_EDGE_OPTIONS_DEFAULTS: AddEdgeOptions = {
   animate: true,
 };
 
+export const LOAD_GRAPH_OPTIONS_DEFAULTS: HistoryOption = {
+  history: true,
+};
+
 export type RemoveEdgeOptions = BroadcastOption & HistoryOption & AnimateOption;
 
 export const REMOVE_EDGE_OPTIONS_DEFAULTS: RemoveEdgeOptions = {

--- a/client/src/graphs/events/types.ts
+++ b/client/src/graphs/events/types.ts
@@ -8,6 +8,7 @@ import type {
   AddEdgeOptions,
   RemoveEdgeOptions,
   EditEdgeLabelOptions,
+  HistoryOption,
 } from '@graph/base/types';
 import type { NodeAnchor } from '@graph/plugins/anchors/types';
 import type { GraphThemeName } from '@graph/themes';
@@ -18,6 +19,7 @@ import type {
 } from '@graph/plugins/history/types';
 import type { BoundingBox, Coordinate } from '@shape/types';
 import type { GraphMouseEvent } from '@graph/base/types';
+import type { GraphState } from '@graph/collab/types';
 
 export type BaseGraphEventMap = {
   /**
@@ -118,7 +120,10 @@ export type BaseGraphEventMap = {
   /**
    * when the graph is {@link Graph.load | loaded} with new nodes and edges.
    */
-  onGraphLoaded: () => void;
+  onGraphLoaded: (
+    previousState: GraphState,
+    historyOptions: HistoryOption,
+  ) => void;
   /**
    * when the graph has {@link Graph.reset | reset} and all nodes and edges have been removed
    */

--- a/client/src/graphs/plugins/history/index.ts
+++ b/client/src/graphs/plugins/history/index.ts
@@ -211,7 +211,7 @@ export const useHistory = (graph: BaseGraph) => {
 
       addToUndoStack({
         action: 'load',
-        newState: [
+        affectedItems: [
           ...graph.nodes.value.map((node) => ({
             graphType: 'node' as const,
             data: node,
@@ -373,10 +373,10 @@ export const useHistory = (graph: BaseGraph) => {
     if (record.action === 'load') {
       graph.load(
         {
-          nodes: record.newState
+          nodes: record.affectedItems
             .filter((item) => item.graphType === 'node')
             .map((item) => item.data),
-          edges: record.newState
+          edges: record.affectedItems
             .filter((item) => item.graphType === 'edge')
             .map((item) => item.data),
         },

--- a/client/src/graphs/plugins/history/index.ts
+++ b/client/src/graphs/plugins/history/index.ts
@@ -211,7 +211,7 @@ export const useHistory = (graph: BaseGraph) => {
 
       addToUndoStack({
         action: 'load',
-        affectedItems: [
+        newState: [
           ...graph.nodes.value.map((node) => ({
             graphType: 'node' as const,
             data: node,
@@ -373,10 +373,10 @@ export const useHistory = (graph: BaseGraph) => {
     if (record.action === 'load') {
       graph.load(
         {
-          nodes: record.affectedItems
+          nodes: record.newState
             .filter((item) => item.graphType === 'node')
             .map((item) => item.data),
-          edges: record.affectedItems
+          edges: record.newState
             .filter((item) => item.graphType === 'edge')
             .map((item) => item.data),
         },

--- a/client/src/graphs/plugins/history/index.ts
+++ b/client/src/graphs/plugins/history/index.ts
@@ -199,34 +199,33 @@ export const useHistory = (graph: BaseGraph) => {
   graph.subscribe(
     'onGraphLoaded',
     (previousState: GraphState, { history }: HistoryOption) => {
-      if (history) {
-        const previousNodes = previousState.nodes.map((node) => ({
-          graphType: 'node' as const,
-          data: node,
-        }));
-        const previousEdges = previousState.edges.map((edge) => ({
-          graphType: 'edge' as const,
-          data: edge,
-        }));
+      if (!history) return;
+      const previousNodes = previousState.nodes.map((node) => ({
+        graphType: 'node' as const,
+        data: node,
+      }));
+      const previousEdges = previousState.edges.map((edge) => ({
+        graphType: 'edge' as const,
+        data: edge,
+      }));
 
-        addToUndoStack({
-          action: 'load',
-          affectedItems: [
-            ...graph.nodes.value.map((node) => ({
-              graphType: 'node' as const,
-              data: node,
-            })),
-            ...graph.edges.value.map((edge) => ({
-              graphType: 'edge' as const,
-              data: edge,
-            })),
-          ],
-          previousState: {
-            nodes: previousNodes,
-            edges: previousEdges,
-          },
-        });
-      }
+      addToUndoStack({
+        action: 'load',
+        affectedItems: [
+          ...graph.nodes.value.map((node) => ({
+            graphType: 'node' as const,
+            data: node,
+          })),
+          ...graph.edges.value.map((edge) => ({
+            graphType: 'edge' as const,
+            data: edge,
+          })),
+        ],
+        previousState: {
+          nodes: previousNodes,
+          edges: previousEdges,
+        },
+      });
     },
   );
 

--- a/client/src/graphs/plugins/history/types.ts
+++ b/client/src/graphs/plugins/history/types.ts
@@ -81,10 +81,36 @@ export type EditRecord = {
 };
 
 /**
+ * a record indicating the entire graph state was loaded
+ */
+export type LoadRecord = {
+  /**
+   * the action that was taken in order to create this record.
+   */
+  action: 'load';
+  /**
+   * the items that were present in the graph when loaded.
+   */
+  affectedItems: (GNodeRecord | GEdgeRecord)[];
+  /**
+   * the previous state of the graph before loading
+   * without this is won't know what was there before
+   */
+  previousState: {
+    nodes: GNodeRecord[];
+    edges: GEdgeRecord[];
+  };
+};
+
+/**
  * a record of an event stored in the history stack of a graph.
  * provides for undo/redo functionality
  */
-export type HistoryRecord = AddRemoveRecord | MoveRecord | EditRecord;
+export type HistoryRecord =
+  | AddRemoveRecord
+  | MoveRecord
+  | EditRecord
+  | LoadRecord;
 
 export type UndoHistoryOptions = FocusOption;
 

--- a/client/src/graphs/plugins/history/types.ts
+++ b/client/src/graphs/plugins/history/types.ts
@@ -81,7 +81,7 @@ export type EditRecord = {
 };
 
 /**
- * a record indicating the graph state was loaded
+ * a record indicating the graph state was *REPLACED* with a new state
  */
 export type LoadRecord = {
   /**
@@ -89,11 +89,11 @@ export type LoadRecord = {
    */
   action: 'load';
   /**
-   * the items that were loaded in.
+   * state that replaced the current state. Also known as new state
    */
   affectedItems: (GNodeRecord | GEdgeRecord)[];
   /**
-   * the state of the graph before loading
+   * the state of the graph before replacement
    */
   previousState: {
     nodes: GNodeRecord[];

--- a/client/src/graphs/plugins/history/types.ts
+++ b/client/src/graphs/plugins/history/types.ts
@@ -91,7 +91,7 @@ export type LoadRecord = {
   /**
    * the items that were loaded in.
    */
-  newState: (GNodeRecord | GEdgeRecord)[];
+  affectedItems: (GNodeRecord | GEdgeRecord)[];
   /**
    * the state of the graph before loading
    */

--- a/client/src/graphs/plugins/history/types.ts
+++ b/client/src/graphs/plugins/history/types.ts
@@ -91,7 +91,7 @@ export type LoadRecord = {
   /**
    * the items that were loaded in.
    */
-  affectedItems: (GNodeRecord | GEdgeRecord)[];
+  newState: (GNodeRecord | GEdgeRecord)[];
   /**
    * the state of the graph before loading
    */

--- a/client/src/graphs/plugins/history/types.ts
+++ b/client/src/graphs/plugins/history/types.ts
@@ -81,7 +81,7 @@ export type EditRecord = {
 };
 
 /**
- * a record indicating the entire graph state was loaded
+ * a record indicating the graph state was loaded
  */
 export type LoadRecord = {
   /**
@@ -89,12 +89,11 @@ export type LoadRecord = {
    */
   action: 'load';
   /**
-   * the items that were present in the graph when loaded.
+   * the items that were loaded in.
    */
   affectedItems: (GNodeRecord | GEdgeRecord)[];
   /**
-   * the previous state of the graph before loading
-   * without this is won't know what was there before
+   * the state of the graph before loading
    */
   previousState: {
     nodes: GNodeRecord[];

--- a/client/src/graphs/plugins/persistent/index.ts
+++ b/client/src/graphs/plugins/persistent/index.ts
@@ -53,10 +53,13 @@ export const usePersistent = (graph: BaseGraph) => {
   };
 
   const load = () =>
-    graph.load({
-      nodes: nodeStorage.get(),
-      edges: edgeStorage.get(),
-    });
+    graph.load(
+      {
+        nodes: nodeStorage.get(),
+        edges: edgeStorage.get(),
+      },
+      { history: false },
+    );
 
   const trackChangeEvents: GraphEvent[] = [
     'onStructureChange',


### PR DESCRIPTION
passes previous state through load
adds the history flag to load options
adds load to history
history correctly tracks load
removes initial load from history

fixes #422