### PR TITLE
fix: add arrow back to transition matrix

### DIFF
--- a/client/src/products/graph-sandbox/ui/GraphInfoMenu/TransitionMatrixLabel.vue
+++ b/client/src/products/graph-sandbox/ui/GraphInfoMenu/TransitionMatrixLabel.vue
@@ -38,7 +38,7 @@
           />
           <CIcon
             class="text-2xl"
-            icon="arrow_right"
+            icon="arrow-right"
           />
           <GraphNode
             :node="fromNode"


### PR DESCRIPTION
for some reason it disappeared. it is now back.