### PR TITLE
fix: add default label to binary tree edge generation

### DIFF
--- a/client/src/products/binary-trees/tree/treeArrayToGraph.ts
+++ b/client/src/products/binary-trees/tree/treeArrayToGraph.ts
@@ -8,7 +8,7 @@ const newEdge = (from: number, to: number) => ({
   from: from.toString(),
   to: to.toString(),
   id: `${from}-${to}`,
-  label: '',
+  label: '1',
 });
 
 const edgesInTree = (treeArray: TreeNodeKeyArray) => {


### PR DESCRIPTION
this fixes go with graph creating empty labels when moving from binary tree to graph sandbox. see issue #326 