### PR TITLE
emit onNodeHoverChange and set hovered node for new nodes

### DIFF
--- a/client/src/graphs/base/index.ts
+++ b/client/src/graphs/base/index.ts
@@ -266,6 +266,14 @@ export const useBaseGraph = (
   updateAggregator.push(liftHoveredNodeToTop);
 
   /**
+   * Sets the current hovered node (e.g. when adding a new node)
+   * @param node - the node to set as hovered
+   */
+  const setCurrHoveredNode = (node: GNode | undefined) => {
+    currHoveredNode = node;
+  };
+
+  /**
    * load a graph state into the graph
    * @param graphState - the graph state to load (nodes and edges)
    */
@@ -354,6 +362,7 @@ export const useBaseGraph = (
      * a mapping of all graph events to a set of their callback functions
      */
     eventBus,
+    setCurrHoveredNode,
     subscribe,
     unsubscribe,
     emit,

--- a/client/src/graphs/plugins/interactive/index.ts
+++ b/client/src/graphs/plugins/interactive/index.ts
@@ -13,7 +13,13 @@ export const useInteractive = (graph: BaseGraph) => {
 
     const nodeAdded = graph.addNode(coords);
     if (!nodeAdded) return;
-    setTimeout(() => graph.updateGraphAtMousePosition(event), 10);
+    setTimeout(() => {
+      graph.updateGraphAtMousePosition(event);
+
+      // The cursor is now hovering this new node
+      graph.setCurrHoveredNode(nodeAdded satisfies GNode);
+      graph.emit('onNodeHoverChange', nodeAdded satisfies GNode, undefined);
+    }, 10);
   };
 
   const doesEdgeConformToRules = (fromNode: GNode, toNode: GNode) => {


### PR DESCRIPTION
Fixes #10 and allows the renderer to bring the newly added node to top