### PR TITLE
fix(canvas): zoom sensitivity capped on mice with excessive deltaY output

### DIFF
--- a/client/src/canvas/camera/panZoom.ts
+++ b/client/src/canvas/camera/panZoom.ts
@@ -17,7 +17,9 @@ export const usePanAndZoom = (canvas: Ref<HTMLCanvasElement | undefined>, storag
   const setZoom = (ev: Pick<WheelEvent, 'clientX' | 'clientY' | 'deltaY'>) => {
     const { clientX: cx, clientY: cy } = ev
 
-    const zoomFactor = Math.exp(-ev.deltaY * ZOOM_SENSITIVITY);
+    // clamp deltaY to a max range to prevent mice with large deltaY notches from feeling too sensitive
+    const normalizedDelta = Math.max(-100, Math.min(100, ev.deltaY));
+    const zoomFactor = Math.exp(-normalizedDelta * ZOOM_SENSITIVITY);
     const clampedZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom.value * zoomFactor));
 
     const scale = clampedZoom / zoom.value;


### PR DESCRIPTION
Fixes #495 

Not sure if this will work since I do not have his mouse to test on, but if we could get the reading of his mouses deltaY outputs we could simulate the notches on his mouse