### PR TITLE
refactor(package.json): organize & optimize scripts

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,16 +6,17 @@
   "scripts": {
     "dev": "vite",
     "test": "vitest",
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "run-p build:js build:storybook \"build:types {@}\" --",
+    "build:js": "vite build",
+    "build:storybook": "storybook build",
+    "build:types": "vue-tsc --build --force",
+    "check": "run-p build:types build:js format:check",
     "preview": "vite preview",
-    "build-only": "vite build",
-    "type-check": "vue-tsc --build --force",
-    "format": "prettier --write .",
-    "format-code-only": "prettier --write \"src/**/*.{js,ts,vue}\"",
-    "lint": "eslint \"**/*.{vue,ts,html}\"",
-    "lint:fix": "eslint \"**/*.{vue,ts,html}\" --fix",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "format": "prettier --cache --write .",
+    "format:check": "prettier --cache --check .",
+    "lint": "eslint --cache .",
+    "lint:fix": "eslint --cache --fix .",
+    "storybook": "storybook dev -p 6006"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.2",


### PR DESCRIPTION
<!-- PR_SUMMARY_START -->
- refactor(package.json): organize & optimize scripts

  - use caching where available
  - make build commands under one group
  - add a new `check` command for testing *everything*

previous pr: [#519](https://github.com/Yonava/magic-graphs/pull/519)
next pr(s): [#521](https://github.com/Yonava/magic-graphs/pull/521)
<!-- PR_SUMMARY_END -->

---

This is a set-up PR for getting CI checks. It also makes the repo more usable and consistent.

Idk if I did a good job categorizing the storybook one. It feels to me like we would also want to include that in build process for a "correct" build but idk. Like, is a build still healthy if storybook does not build? I did not think so, so I make it included in general build process.